### PR TITLE
Add realtime chart and subscription API

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -5,7 +5,7 @@ import requests
 import logging
 from datetime import datetime, timedelta
 import pandas as pd
-from flask import Flask, send_from_directory, render_template
+from flask import Flask, send_from_directory, render_template, request
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -274,6 +274,16 @@ def serve_day():
 @app.route('/data.json')
 def serve_full():
     return send_from_directory('.', FULL_DATA_FILE)
+
+
+@app.route('/recipient_mails.json', methods=['GET', 'PUT'])
+def handle_recipients():
+    """Serve and update subscription emails."""
+    if request.method == 'GET':
+        return send_from_directory('.', RECIPIENT_FILE)
+    data = request.get_json(force=True)
+    save_json(RECIPIENT_FILE, data)
+    return '', 204
 
 
 # shared queue for alerts

--- a/templates/index.html
+++ b/templates/index.html
@@ -163,7 +163,7 @@
         </header>
         
         <div class="chart-container">
-            <img src="static/fuel_prices_chart.png" alt="油价走势图" class="chart-img">
+            <canvas id="priceChart" class="chart-img"></canvas>
         </div>
         
         <div class="form-control">
@@ -182,6 +182,8 @@
         </footer>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
     <script src="static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize frontend for interactive multi-fuel chart
- fetch price data periodically on the page
- expose recipient list API in monitor backend
- handle subscription via existing page

## Testing
- `python -m py_compile monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_684261af1e488333807bcc18b17aa1ed