### PR TITLE
Fix alert subscription and UI improvements

### DIFF
--- a/static/subscribe.js
+++ b/static/subscribe.js
@@ -3,6 +3,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const methodSel = document.getElementById('method');
     const alertOptions = document.getElementById('alertOptions');
     const thresholdInput = document.getElementById('threshold');
+    const maInput = document.getElementById('maWindow');
+    const sendBtn = document.getElementById('sendCode');
+    let countdown = 0;
 
     alertCheck.addEventListener('change', () => {
         alertOptions.style.display = alertCheck.checked ? 'block' : 'none';
@@ -10,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     methodSel.addEventListener('change', () => {
         thresholdInput.style.display = methodSel.value === 'fixed' ? 'inline' : 'none';
+        maInput.style.display = methodSel.value === 'moving_average' ? 'inline' : 'none';
     });
 
     document.getElementById('next').onclick = () => {
@@ -17,16 +21,44 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('step2').style.display = 'block';
     };
 
-    document.getElementById('sendCode').onclick = () => {
+    function startCountdown() {
+        countdown = 60;
+        sendBtn.disabled = true;
+        sendBtn.textContent = `Send Code (${countdown})`;
+        const timer = setInterval(() => {
+            countdown--;
+            sendBtn.textContent = `Send Code (${countdown})`;
+            if (countdown <= 0) {
+                clearInterval(timer);
+                sendBtn.disabled = false;
+                sendBtn.textContent = 'Send Code';
+            }
+        }, 1000);
+    }
+
+    sendBtn.onclick = () => {
         const email = document.getElementById('email').value;
-        fetch('/send_code', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
+        if (!email) return;
+        fetch('/send_code', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})})
+            .then(res => {
+                if (res.ok) {
+                    startCountdown();
+                } else {
+                    res.json().then(d => alert(d.error || 'Failed'));
+                }
+            });
     };
 
     document.getElementById('submit').onclick = () => {
         const email = document.getElementById('email').value;
         const code = document.getElementById('code').value;
         const weekly = document.getElementById('weekly').checked;
-        const alerts = alertCheck.checked ? [{fuel_type: document.getElementById('fuelType').value, method: methodSel.value, threshold: parseFloat(thresholdInput.value) || undefined}] : [];
+        const alerts = alertCheck.checked ? [{
+            fuel_type: document.getElementById('fuelType').value,
+            method: methodSel.value,
+            threshold: parseFloat(thresholdInput.value) || undefined,
+            ma_window: parseInt(maInput.value) || undefined
+        }] : [];
         fetch('/subscribe', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, code, weekly, alerts})})
             .then(r => {if(r.ok) window.location='/';});
     };

--- a/static/unsubscribe.js
+++ b/static/unsubscribe.js
@@ -1,7 +1,33 @@
 document.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('sendCode').onclick = () => {
+    const sendBtn = document.getElementById('sendCode');
+    let countdown = 0;
+
+    function startCountdown() {
+        countdown = 60;
+        sendBtn.disabled = true;
+        sendBtn.textContent = `Send Code (${countdown})`;
+        const timer = setInterval(() => {
+            countdown--;
+            sendBtn.textContent = `Send Code (${countdown})`;
+            if (countdown <= 0) {
+                clearInterval(timer);
+                sendBtn.disabled = false;
+                sendBtn.textContent = 'Send Code';
+            }
+        }, 1000);
+    }
+
+    sendBtn.onclick = () => {
         const email = document.getElementById('email').value;
-        fetch('/send_code', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
+        if (!email) return;
+        fetch('/send_code', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})})
+            .then(res => {
+                if (res.ok) {
+                    startCountdown();
+                } else {
+                    res.json().then(d => alert(d.error || 'Failed'));
+                }
+            });
     };
     document.getElementById('submit').onclick = () => {
         const email = document.getElementById('email').value;

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -5,8 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Subscribe</title>
     <style>
-        body {font-family: Arial, sans-serif; padding: 20px; max-width: 600px; margin:auto;}
-        .step {margin-bottom:20px;}
+        body {font-family: Arial, sans-serif; padding: 20px; max-width: 600px; margin:auto; background:#f4f6f8;}
+        .step {margin-bottom:20px; background:white; padding:20px; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1);}        
+        input, select, button {margin-top:8px; padding:8px 12px; border-radius:4px; border:1px solid #ccc; font-size:14px;}
+        button {cursor:pointer; background:#3498db; color:white; border:none;}
+        button:disabled {background:#ccc; cursor:not-allowed;}
     </style>
 </head>
 <body>
@@ -30,6 +33,7 @@
                 </select>
             </label>
             <input id="threshold" type="number" placeholder="Threshold" style="display:none;">
+            <input id="maWindow" type="number" placeholder="MA days" style="display:none;">
         </div>
         <button id="next">Next</button>
     </div>

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -4,13 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Unsubscribe</title>
+    <style>
+        body{font-family:Arial, sans-serif; background:#f4f6f8; padding:20px; max-width:600px; margin:auto;}
+        .box{background:white; padding:20px; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1);}
+        input,button{margin-top:8px; padding:8px 12px; border-radius:4px; border:1px solid #ccc; font-size:14px;}
+        button{background:#e74c3c; color:white; border:none; cursor:pointer;}
+        button:disabled{background:#ccc; cursor:not-allowed;}
+    </style>
 </head>
 <body>
-    <h1>Unsubscribe</h1>
-    <input id="email" type="email" placeholder="Email"><br>
-    <button id="sendCode">Send Code</button><br>
-    <input id="code" placeholder="Verification code"><br>
-    <button id="submit">Submit</button>
+    <div class="box">
+        <h1>Unsubscribe</h1>
+        <input id="email" type="email" placeholder="Email"><br>
+        <button id="sendCode">Send Code</button><br>
+        <input id="code" placeholder="Verification code"><br>
+        <button id="submit">Submit</button>
+    </div>
     <script src="/static/unsubscribe.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- repair loading of old subscription format and add cooldown when sending verification codes
- allow custom moving average window
- style subscribe/unsubscribe pages and add countdown for sending codes
- enhance verification email styling

## Testing
- `python -m py_compile monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_684275ea2c6c833399688ee20110c9d8